### PR TITLE
Replaced the <% and %> with ${ and } as the new template literal.

### DIFF
--- a/04 - Templates/0400 - Gen_Note.md
+++ b/04 - Templates/0400 - Gen_Note.md
@@ -140,8 +140,8 @@ async function setMetadata(inTag) {
 // Name: setTimestamps
 // Description: Builds the timestamps element appended to note pages as they're built. Includes the definition of the Modified Date dynamic element which is updated when the page is edited and shown at the time of the page being rendered in preview mode.
 async function setTimestamps() {
-	var timestamps = "\nCreated Date: " + tp.file.creation_date('MMMM Do YYYY (hh:ss a)') + "  \nLast Modified Date: <%+tp.file.last_modified_date(\"MMMM Do YYYY (hh:ss a)\")%>";
-	
+	var timestamps = `\nCreated Date: ${tp.file.creation_date('MMMM Do YYYY @hh:ss a')} \nLast Modified Date: ${tp.file.last_modified_date('MMMM Do YYYY @hh:ss a')}`;
+
 	return timestamps;
 }
 


### PR DESCRIPTION
Fixes the template syntax error: Invalid or unexpected token on the latest version of Templater and Obsidian.